### PR TITLE
#56 Uses remote image url to display cards thumbnails

### DIFF
--- a/app/jobs/get_video_metadata_job.rb
+++ b/app/jobs/get_video_metadata_job.rb
@@ -1,6 +1,5 @@
 class GetVideoMetadataJob < ApplicationJob
   queue_as :default
-
   def perform(link)
     begin
       @lt = LinkThumbnailer.generate(link.url)
@@ -25,6 +24,8 @@ class GetVideoMetadataJob < ApplicationJob
     if @lt.images.count > 0
       img = @lt.images.first
       @thumbnail.source = img.src
+      # Is this really needed?
+      # Why are we dowloading the file to public?
       dir_path = File.join Rails.root, 'public', 'downloads', 'users', link.user_id.to_s, 'images'
       FileUtils.mkdir_p(dir_path) unless File.exist?(dir_path)
       download_image(img.src, File.join(dir_path, (URI(img.src).path).split('/').last))

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -56,7 +56,7 @@ class Link < ApplicationRecord
     if self.thumbnail.nil? or self.thumbnail.source.nil?
       return "//via.placeholder.com/#{width}x#{height}"
     else
-      self.thumbnail.source
+      self.thumbnail.remote_image.url
     end
   end
 

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -2,7 +2,7 @@ require 'resque/tasks'
 require 'resque/scheduler/tasks'
 
 namespace :resque do
-  task :setup do
+  task setup: :environment do
     require 'resque'
     require 'resque-scheduler'
   end


### PR DESCRIPTION
Thumbnail links are already using the S3 bucket but locally i am having an error when accessing the image.
```
<Error>
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Key>c8c2cf02/54-maxresdefault.jpg</Key>
<RequestId>0BDD39CD5158AB1F</RequestId>
<HostId>
HaTnveK6HMjQVLs3sKDpDcA5+0YkqcaNQPyCy9WQg4y/Nj2/c2VGIGjraTRclLMS2qZlFZU3UHI=
</HostId>
</Error>
```