### PR TITLE
Altered remote_image_uploader store_dir

### DIFF
--- a/app/uploaders/remote_image_uploader.rb
+++ b/app/uploaders/remote_image_uploader.rb
@@ -11,7 +11,7 @@ class RemoteImageUploader < CarrierWave::Uploader::Base
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     # "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-    "#{SecureRandom.hex(4)}"
+    "#{Digest::MD5.hexdigest(model.id.to_s)[0..5]}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:


### PR DESCRIPTION
@elubow So the problem was indeed on the store_dir function. We cant use SecureRandom.hex(4) because it will generate different paths even if we pass the same information. This would make it impossible to point to the correct bucket.